### PR TITLE
Change engine name

### DIFF
--- a/services/eta/call_options.go
+++ b/services/eta/call_options.go
@@ -18,7 +18,7 @@ const (
 	EtaEngineZeus
 	EtaEngineCarPooling
 	EtaEngineGolchin
-	EtaEngineGiraffe
+	EtaEngineZarrafe
 	EtaEngineFood
 	EtaEngineIntercity
 )
@@ -50,8 +50,8 @@ func (engine EtaEngine) String() string {
 		return "carpooling"
 	case EtaEngineGolchin:
 		return "golchin"
-	case EtaEngineGiraffe:
-		return "giraffe"
+	case EtaEngineZarrafe:
+		return "zarrafe"
 	case EtaEngineFood:
 		return "food"
 	case EtaEngineIntercity:

--- a/services/matrix/call_options.go
+++ b/services/matrix/call_options.go
@@ -17,7 +17,7 @@ const (
 	MatrixEngineZeus
 	MatrixEngineCarPooling
 	MatrixEngineGolchin
-	MatrixEngineGiraffe
+	MatrixEngineZarrafe
 	MatrixEngineFood
 	MatrixEngineIntercity
 )
@@ -47,8 +47,8 @@ func (engine MatrixEngine) String() string {
 		return "carpooling"
 	case MatrixEngineGolchin:
 		return "golchin"
-	case MatrixEngineGiraffe:
-		return "giraffe"
+	case MatrixEngineZarrafe:
+		return "zarrafe"
 	case MatrixEngineFood:
 		return "food"
 	case MatrixEngineIntercity:

--- a/version/version.go
+++ b/version/version.go
@@ -3,7 +3,7 @@ package version
 import "fmt"
 
 const (
-	Version         = "v0.9.19"
+	Version         = "v0.9.20"
 	UserAgentHeader = "User-Agent"
 )
 


### PR DESCRIPTION
We just changed the engine for Zarrafe from "_giraffe_" to "_zarrafe_" to unifying services names