### PR TITLE
feat(smappshot): add smappshot URL builder service

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,8 +19,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: '1.26'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1
+          version: latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.24
+      image: golang:1.26
     steps:
       - uses: actions/checkout@v2
       - name: Set GOFLAGS to disable VCS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,8 @@ No Makefile — use `go` CLI directly.
 
 ## Architecture
 
-Go SDK for Snapp mapping services. Five service clients under `services/`, shared config under `config/`.
+
+Go SDK for Snapp mapping services. Six service clients under `services/`, shared config under `config/`.
 
 ### Service Clients
 
@@ -36,6 +37,13 @@ Go SDK for Snapp mapping services. Five service clients under `services/`, share
 | `services/area-gateways` | Geographic area polygons and gateways |
 | `services/eta` | Estimated time of arrival between points |
 | `services/matrix` | Distance/time matrix for source→target pairs |
+| `services/smappshot` | HMAC-SHA256 signed URLs for ride/preview map photos |
+
+### smappshot Exception
+
+`smappshot` does **not** follow the standard service pattern — it is a pure URL builder with no HTTP calls, no `Client`, no `Interface`, no mock.
+Uses `NewRideRequestBuilder(baseURL, signingConfig, version).WithX().Build()` → `(string, error)`.
+Tests use builders exclusively; never construct request structs directly.
 
 ### Consistent Service Pattern
 
@@ -64,6 +72,10 @@ Regions: `teh-1` (default), `teh-2`.
 ### Version
 
 `version/version.go` — single constant, used as `User-Agent: smapp-sdk-go/{Version}`.
+
+## Go Version
+
+`go 1.26` — golangci-lint v2.1.x requires Go 1.26. Keep `go.mod` and both workflow files (`golangci-lint.yml`, `test.yml`) in sync.
 
 ## Adding a New Service
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Test with race detector
+go test -race $(go list ./... | grep -v /vendor/) -v -coverprofile=coverage.out
+
+# Single package test
+go test -race ./services/reverse/... -v
+
+# Lint
+golangci-lint run
+
+# Coverage (exclude mocks, matching CI)
+grep -v "mock.go" coverage.out > cover.out && go tool cover -func=cover.out
+
+# Dependencies
+go mod download && go mod tidy
+```
+
+No Makefile — use `go` CLI directly.
+
+## Architecture
+
+Go SDK for Snapp mapping services. Five service clients under `services/`, shared config under `config/`.
+
+### Service Clients
+
+| Package | Purpose |
+|---|---|
+| `services/reverse` | Lat/lon → address (components, display name, structural) |
+| `services/search` | Place search, autocomplete, city lookup |
+| `services/area-gateways` | Geographic area polygons and gateways |
+| `services/eta` | Estimated time of arrival between points |
+| `services/matrix` | Distance/time matrix for source→target pairs |
+
+### Consistent Service Pattern
+
+Every service has:
+- `Interface` — defines all operations (enables mocking)
+- `Client` struct — concrete implementation
+- `NewClient(cfg, version, timeout, ...ClientOption)` — constructor
+- `CallOptions` — per-request options (custom headers, OpenTelemetry tracer)
+- `*_mock.go` — generated mock via `go.uber.org/mock`
+- All operations have `WithContext` variants
+
+### Config
+
+`config.Config` holds: `APIKey`, `Region`, `APIKeySource` (header/query), `APIKeyName`, `APIBaseURL`.
+
+Environment variables: `SMAPP_API_KEY` (required), `SMAPP_API_KEY_SOURCE`, `SMAPP_API_KEY_NAME`, `SMAPP_API_REGION`, `SMAPP_API_BASE_URL`.
+
+Regions: `teh-1` (default), `teh-2`.
+
+### HTTP & Observability
+
+- API key injected via header (`X-Smapp-Key`) or query param (`monshi_key`)
+- OpenTelemetry tracing via `otelhttp` — enable with `WithRequestOpenTelemetryTracing(tracerName)` CallOption
+- Customizable HTTP transport via `ClientOption`
+
+### Version
+
+`version/version.go` — single constant, used as `User-Agent: smapp-sdk-go/{Version}`.
+
+## Adding a New Service
+
+Follow the pattern of an existing service (e.g., `services/eta`): define `Interface`, implement `Client`, add `options.go`, `call_options.go`, `models.go`, and generate mock with `go.uber.org/mock`.
+
+Regenerate mock after changing an `Interface`:
+```bash
+mockgen -source services/{name}/{name}.go -destination=services/{name}/{name}_mock.go -mock_names Interface=Mock{Name}Client -package={pkg}
+```
+Exact command in each `*_mock.go` file header comment.

--- a/examples/smappshot-baly/main.go
+++ b/examples/smappshot-baly/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/snapp-incubator/smapp-sdk-go/services/smappshot"
+)
+
+func main() {
+	secret := os.Getenv("SMAPPSHOT_SIGNING_SECRET")
+
+	// Ride — Baghdad, Iraq
+	rideURL, err := smappshot.NewRideRequestBuilder("http://localhost:8080", secret, smappshot.V1).
+		WithOrigin(smappshot.Location{Lat: 33.3152, Lon: 44.3661}).
+		WithDestinations([]smappshot.Location{
+			{Lat: 33.3600, Lon: 44.4000},
+		}).
+		WithLanguage(smappshot.LanguageEnglish).
+		WithExpiry(10 * time.Minute).
+		Build()
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("=== Ride (Baghdad) ===")
+	fmt.Printf("curl -o /tmp/ride.png -w \"%%{http_code}\\n\" \"%s\"\n\n", rideURL)
+
+	// Preview — Beirut, Lebanon
+	previewURL, err := smappshot.NewPreviewRequestBuilder("http://localhost:8080", secret, smappshot.V1).
+		WithCenter(smappshot.Location{Lat: 33.8938, Lon: 35.5018}).
+		WithZoom(14).
+		WithLanguage(smappshot.LanguageEnglish).
+		WithExpiry(10 * time.Minute).
+		Build()
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("=== Preview (Beirut) ===")
+	fmt.Printf("curl -o /tmp/preview.png -w \"%%{http_code}\\n\" \"%s\"\n", previewURL)
+}

--- a/examples/smappshot-baly/verify.go
+++ b/examples/smappshot-baly/verify.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// serverComputeSignature mirrors signed_url.go computeSignature exactly
+func serverComputeSignature(secret, path string, q url.Values) string {
+	keys := make([]string, 0, len(q))
+	for k := range q {
+		if strings.ToLower(k) == "sig" {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return strings.ToLower(keys[i]) < strings.ToLower(keys[j])
+	})
+
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, url.QueryEscape(k)+"="+url.QueryEscape(q.Get(k)))
+	}
+	serialized := strings.Join(parts, "&")
+	message := "GET\n" + path + "\n" + serialized
+	fmt.Println("Server message:", message)
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(message))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func init() {
+	// Parse the generated URL and verify server-side
+	rawURL := "http://localhost:8080/api/v1/photo/ride?destinations=44.4%2C33.36&expires=1780756467&height=285&language=en&marker_type=0&origin=44.3661%2C33.3152&width=512&sig=e196ef3f0dbbecfde02aa17e740839c8201e0d4bbf52c9c4a80f622c1e1d2fbc"
+	secret := "5fe9e0d860b7aa3409f41cca3c5f41359124988fb28cbcf58005eb0fc0f21a25"
+
+	u, _ := url.Parse(rawURL)
+	q := u.Query()
+
+	serverSig := serverComputeSignature(secret, u.Path, q)
+	sdkSig := q.Get("sig")
+
+	fmt.Println("SDK sig:   ", sdkSig)
+	fmt.Println("Server sig:", serverSig)
+	fmt.Println("Match:", serverSig == sdkSig)
+}

--- a/examples/smappshot/main.go
+++ b/examples/smappshot/main.go
@@ -9,17 +9,15 @@ import (
 )
 
 func main() {
-	cfg := smappshot.SigningConfig{
-		Secret:         "my-secret", // replace with real secret
-		ExpiryDuration: 10 * time.Minute,
-	}
+	secret := "my-secret" // replace with real secret
 
-	rideURL, err := smappshot.NewRideRequestBuilder("https://smappshot.snappmaps.ir", cfg, smappshot.V1).
+	rideURL, err := smappshot.NewRideRequestBuilder("https://smappshot.snappmaps.ir", secret, smappshot.V1).
 		WithOrigin(smappshot.Location{Lon: 51.338, Lat: 35.699}).
 		WithDestinations([]smappshot.Location{
 			{Lon: 51.400, Lat: 35.720},
 		}).
 		WithLanguage(smappshot.LanguageFarsi).
+		WithExpiry(10 * time.Minute).
 		Build()
 	if err != nil {
 		log.Fatal(err)
@@ -28,10 +26,11 @@ func main() {
 	fmt.Println(rideURL)
 	fmt.Println()
 
-	previewURL, err := smappshot.NewPreviewRequestBuilder("https://smappshot.snappmaps.ir", cfg, smappshot.V1).
+	previewURL, err := smappshot.NewPreviewRequestBuilder("https://smappshot.snappmaps.ir", secret, smappshot.V1).
 		WithCenter(smappshot.Location{Lon: 51.338, Lat: 35.699}).
 		WithZoom(14).
 		WithLanguage(smappshot.LanguageFarsi).
+		WithExpiry(10 * time.Minute).
 		Build()
 	if err != nil {
 		log.Fatal(err)

--- a/examples/smappshot/main.go
+++ b/examples/smappshot/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/snapp-incubator/smapp-sdk-go/services/smappshot"
+)
+
+func main() {
+	cfg := smappshot.SigningConfig{
+		Secret:         "my-secret", // replace with real secret
+		ExpiryDuration: 10 * time.Minute,
+	}
+
+	rideURL, err := smappshot.NewRideRequestBuilder("https://smappshot.snappmaps.ir", cfg, smappshot.V1).
+		WithOrigin(smappshot.Location{Lon: 51.338, Lat: 35.699}).
+		WithDestinations([]smappshot.Location{
+			{Lon: 51.400, Lat: 35.720},
+		}).
+		WithLanguage(smappshot.LanguageFarsi).
+		Build()
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("Ride URL:")
+	fmt.Println(rideURL)
+	fmt.Println()
+
+	previewURL, err := smappshot.NewPreviewRequestBuilder("https://smappshot.snappmaps.ir", cfg, smappshot.V1).
+		WithCenter(smappshot.Location{Lon: 51.338, Lat: 35.699}).
+		WithZoom(14).
+		WithLanguage(smappshot.LanguageFarsi).
+		Build()
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("Preview URL:")
+	fmt.Println(previewURL)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snapp-incubator/smapp-sdk-go
 
-go 1.24
+go 1.26
 
 require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.62.0

--- a/services/smappshot/builder.go
+++ b/services/smappshot/builder.go
@@ -1,12 +1,8 @@
 package smappshot
 
 import (
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"net/url"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -30,13 +26,13 @@ type RideRequestBuilder struct {
 	version        Version
 	width          int
 	height         int
+	language       Language
+	style          string
+	tenant         Tenant
 	here           *Location
 	origin         *Location
 	destinations   []Location
-	language       Language
-	style          string
 	markerType     MarkerType
-	tenant         string
 }
 
 // NewRideRequestBuilder creates a builder for the ride photo URL.
@@ -65,6 +61,21 @@ func (b *RideRequestBuilder) WithExpiry(d time.Duration) *RideRequestBuilder {
 	return b
 }
 
+func (b *RideRequestBuilder) WithLanguage(lang Language) *RideRequestBuilder {
+	b.language = lang
+	return b
+}
+
+func (b *RideRequestBuilder) WithStyle(style string) *RideRequestBuilder {
+	b.style = style
+	return b
+}
+
+func (b *RideRequestBuilder) WithTenant(tenant Tenant) *RideRequestBuilder {
+	b.tenant = tenant
+	return b
+}
+
 // WithHere sets single-point mode. Clears Origin and Destinations.
 func (b *RideRequestBuilder) WithHere(loc Location) *RideRequestBuilder {
 	b.here = &loc
@@ -87,23 +98,8 @@ func (b *RideRequestBuilder) WithDestinations(dests []Location) *RideRequestBuil
 	return b
 }
 
-func (b *RideRequestBuilder) WithLanguage(lang Language) *RideRequestBuilder {
-	b.language = lang
-	return b
-}
-
-func (b *RideRequestBuilder) WithStyle(style string) *RideRequestBuilder {
-	b.style = style
-	return b
-}
-
 func (b *RideRequestBuilder) WithMarkerType(mt MarkerType) *RideRequestBuilder {
 	b.markerType = mt
-	return b
-}
-
-func (b *RideRequestBuilder) WithTenant(tenant string) *RideRequestBuilder {
-	b.tenant = tenant
 	return b
 }
 
@@ -137,7 +133,7 @@ func (b *RideRequestBuilder) Build() (string, error) {
 	params.Set("marker_type", strconv.Itoa(int(b.markerType)))
 
 	if b.tenant != "" {
-		params.Set("tenant", b.tenant)
+		params.Set("tenant", string(b.tenant))
 	}
 
 	return signURL(b.baseURL, fmt.Sprintf("/api/%s/photo/ride", b.version), b.secret, b.expiryDuration, params)
@@ -156,6 +152,11 @@ func (b *RideRequestBuilder) validate() error {
 	if b.version == "" {
 		return fmt.Errorf("smapp smappshot: version is required")
 	}
+	if b.language != "" {
+		if err := validateLanguage(b.language); err != nil {
+			return err
+		}
+	}
 	if b.here == nil {
 		if b.origin == nil {
 			return fmt.Errorf("smapp smappshot: origin is required when here is not set")
@@ -164,12 +165,6 @@ func (b *RideRequestBuilder) validate() error {
 			return fmt.Errorf("smapp smappshot: at least one destination is required when here is not set")
 		}
 	}
-	if b.language != "" {
-		if err := validateLanguage(b.language); err != nil {
-			return err
-		}
-	}
-	// MarkerTypeRideHistory=0 is the zero value, so an unset MarkerType is valid by default.
 	if b.markerType != MarkerTypeRideHistory && b.markerType != MarkerTypeLocationShare {
 		return fmt.Errorf("smapp smappshot: marker_type must be 0 or 1, got %d", int(b.markerType))
 	}
@@ -191,11 +186,11 @@ type PreviewRequestBuilder struct {
 	version        Version
 	width          int
 	height         int
-	center         *Location
-	zoom           int
 	language       Language
 	style          string
-	tenant         string
+	tenant         Tenant
+	center         *Location
+	zoom           int
 }
 
 // NewPreviewRequestBuilder creates a builder for the preview photo URL.
@@ -224,16 +219,6 @@ func (b *PreviewRequestBuilder) WithExpiry(d time.Duration) *PreviewRequestBuild
 	return b
 }
 
-func (b *PreviewRequestBuilder) WithCenter(loc Location) *PreviewRequestBuilder {
-	b.center = &loc
-	return b
-}
-
-func (b *PreviewRequestBuilder) WithZoom(zoom int) *PreviewRequestBuilder {
-	b.zoom = zoom
-	return b
-}
-
 func (b *PreviewRequestBuilder) WithLanguage(lang Language) *PreviewRequestBuilder {
 	b.language = lang
 	return b
@@ -244,8 +229,18 @@ func (b *PreviewRequestBuilder) WithStyle(style string) *PreviewRequestBuilder {
 	return b
 }
 
-func (b *PreviewRequestBuilder) WithTenant(tenant string) *PreviewRequestBuilder {
+func (b *PreviewRequestBuilder) WithTenant(tenant Tenant) *PreviewRequestBuilder {
 	b.tenant = tenant
+	return b
+}
+
+func (b *PreviewRequestBuilder) WithCenter(loc Location) *PreviewRequestBuilder {
+	b.center = &loc
+	return b
+}
+
+func (b *PreviewRequestBuilder) WithZoom(zoom int) *PreviewRequestBuilder {
+	b.zoom = zoom
 	return b
 }
 
@@ -267,7 +262,7 @@ func (b *PreviewRequestBuilder) Build() (string, error) {
 	}
 
 	if b.tenant != "" {
-		params.Set("tenant", b.tenant)
+		params.Set("tenant", string(b.tenant))
 	}
 
 	return signURL(b.baseURL, fmt.Sprintf("/api/%s/photo/preview", b.version), b.secret, b.expiryDuration, params)
@@ -286,85 +281,13 @@ func (b *PreviewRequestBuilder) validate() error {
 	if b.version == "" {
 		return fmt.Errorf("smapp smappshot: version is required")
 	}
-	if b.center == nil {
-		return fmt.Errorf("smapp smappshot: center is required")
-	}
 	if b.language != "" {
 		if err := validateLanguage(b.language); err != nil {
 			return err
 		}
 	}
+	if b.center == nil {
+		return fmt.Errorf("smapp smappshot: center is required")
+	}
 	return nil
-}
-
-// signURL computes HMAC-SHA256 sig and returns the full signed URL.
-func signURL(baseURL, path, secret string, expiry time.Duration, params url.Values) (string, error) {
-	p := make(url.Values, len(params)+1)
-	for k, v := range params {
-		p[k] = v
-	}
-	p.Set("expires", strconv.FormatInt(time.Now().UTC().Add(expiry).Unix(), 10))
-
-	sig, err := computeSignature(secret, path, p)
-	if err != nil {
-		return "", fmt.Errorf("smapp smappshot: signing failed: %w", err)
-	}
-
-	return baseURL + path + "?" + encodeParamsSorted(p) + "&sig=" + sig, nil
-}
-
-// computeSignature returns hex(HMAC-SHA256(secret, "GET\n{path}\n{sorted-params}")).
-func computeSignature(secret, path string, params url.Values) (string, error) {
-	message := "GET\n" + path + "\n" + encodeParamsSorted(params)
-	mac := hmac.New(sha256.New, []byte(secret))
-	if _, err := mac.Write([]byte(message)); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(mac.Sum(nil)), nil
-}
-
-// encodeParamsSorted sorts keys case-insensitively and percent-encodes key=value pairs.
-// sig must be excluded before calling.
-func encodeParamsSorted(params url.Values) string {
-	keys := make([]string, 0, len(params))
-	for k := range params {
-		keys = append(keys, k)
-	}
-	sort.Slice(keys, func(i, j int) bool {
-		return strings.ToLower(keys[i]) < strings.ToLower(keys[j])
-	})
-	parts := make([]string, 0, len(keys))
-	for _, k := range keys {
-		for _, v := range params[k] {
-			parts = append(parts, url.QueryEscape(k)+"="+url.QueryEscape(v))
-		}
-	}
-	return strings.Join(parts, "&")
-}
-
-// formatLocation serializes a Location as "{lon},{lat}".
-func formatLocation(loc Location) string {
-	return strconv.FormatFloat(loc.Lon, 'f', -1, 64) + "," + strconv.FormatFloat(loc.Lat, 'f', -1, 64)
-}
-
-func validateLanguage(lang Language) error {
-	switch lang {
-	case LanguageFarsi, LanguageEnglish, LanguageArabic, LanguageKurdish:
-		return nil
-	}
-	return fmt.Errorf("smapp smappshot: language must be one of fa, en, ar, ku, got %q", string(lang))
-}
-
-func defaultInt(val, fallback int) int {
-	if val == 0 {
-		return fallback
-	}
-	return val
-}
-
-func defaultLanguage(lang Language) Language {
-	if lang == "" {
-		return LanguageFarsi
-	}
-	return lang
 }

--- a/services/smappshot/builder.go
+++ b/services/smappshot/builder.go
@@ -1,0 +1,356 @@
+package smappshot
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// RideRequestBuilder builds and signs a URL for the /api/{version}/photo/ride endpoint.
+// Either WithHere (single-point mode) or WithOrigin+WithDestinations (route mode) must be called.
+//
+// Usage:
+//
+//	url, err := smappshot.NewRideRequestBuilder(baseURL, signingConfig, smappshot.V1).
+//	    WithOrigin(smappshot.Location{Lon: 51.338, Lat: 35.699}).
+//	    WithDestinations([]smappshot.Location{{Lon: 51.400, Lat: 35.720}}).
+//	    Build()
+type RideRequestBuilder struct {
+	baseURL       string
+	signingConfig SigningConfig
+	version       Version
+	width         int
+	height        int
+	here          *Location
+	origin        *Location
+	destinations  []Location
+	language      Language
+	style         string
+	markerType    MarkerType
+	tenant        string
+}
+
+// NewRideRequestBuilder creates a builder for the ride photo URL.
+func NewRideRequestBuilder(baseURL string, signingConfig SigningConfig, version Version) *RideRequestBuilder {
+	return &RideRequestBuilder{
+		baseURL:       strings.TrimRight(baseURL, "/"),
+		signingConfig: signingConfig,
+		version:       version,
+	}
+}
+
+func (b *RideRequestBuilder) WithWidth(w int) *RideRequestBuilder {
+	b.width = w
+	return b
+}
+
+func (b *RideRequestBuilder) WithHeight(h int) *RideRequestBuilder {
+	b.height = h
+	return b
+}
+
+// WithHere sets single-point mode. Clears Origin and Destinations.
+func (b *RideRequestBuilder) WithHere(loc Location) *RideRequestBuilder {
+	b.here = &loc
+	b.origin = nil
+	b.destinations = nil
+	return b
+}
+
+// WithOrigin sets the route origin. Clears Here.
+func (b *RideRequestBuilder) WithOrigin(loc Location) *RideRequestBuilder {
+	b.origin = &loc
+	b.here = nil
+	return b
+}
+
+// WithDestinations sets route destinations. Clears Here.
+func (b *RideRequestBuilder) WithDestinations(dests []Location) *RideRequestBuilder {
+	b.destinations = dests
+	b.here = nil
+	return b
+}
+
+func (b *RideRequestBuilder) WithLanguage(lang Language) *RideRequestBuilder {
+	b.language = lang
+	return b
+}
+
+func (b *RideRequestBuilder) WithStyle(style string) *RideRequestBuilder {
+	b.style = style
+	return b
+}
+
+func (b *RideRequestBuilder) WithMarkerType(mt MarkerType) *RideRequestBuilder {
+	b.markerType = mt
+	return b
+}
+
+func (b *RideRequestBuilder) WithTenant(tenant string) *RideRequestBuilder {
+	b.tenant = tenant
+	return b
+}
+
+// Build validates, signs, and returns the ride photo URL.
+func (b *RideRequestBuilder) Build() (string, error) {
+	if err := b.validate(); err != nil {
+		return "", err
+	}
+
+	params := url.Values{}
+	params.Set("width", strconv.Itoa(defaultInt(b.width, 512)))
+	params.Set("height", strconv.Itoa(defaultInt(b.height, 285)))
+
+	if b.here != nil {
+		params.Set("here", formatLocation(*b.here))
+	} else {
+		params.Set("origin", formatLocation(*b.origin))
+		dests := make([]string, len(b.destinations))
+		for i, d := range b.destinations {
+			dests[i] = formatLocation(d)
+		}
+		params.Set("destinations", strings.Join(dests, ";"))
+	}
+
+	params.Set("language", string(defaultLanguage(b.language)))
+
+	if b.style != "" {
+		params.Set("style", b.style)
+	}
+
+	params.Set("marker_type", strconv.Itoa(int(b.markerType)))
+
+	if b.tenant != "" {
+		params.Set("tenant", b.tenant)
+	}
+
+	return signURL(b.baseURL, fmt.Sprintf("/api/%s/photo/ride", b.version), b.signingConfig, params)
+}
+
+func (b *RideRequestBuilder) validate() error {
+	if err := validateSigningConfig(b.baseURL, b.signingConfig); err != nil {
+		return err
+	}
+	if b.version == "" {
+		return fmt.Errorf("smapp smappshot: version is required")
+	}
+	if b.here == nil {
+		if b.origin == nil {
+			return fmt.Errorf("smapp smappshot: origin is required when here is not set")
+		}
+		if len(b.destinations) == 0 {
+			return fmt.Errorf("smapp smappshot: at least one destination is required when here is not set")
+		}
+	}
+	if b.language != "" {
+		if err := validateLanguage(b.language); err != nil {
+			return err
+		}
+	}
+	// MarkerTypeRideHistory=0 is the zero value, so an unset MarkerType is valid by default.
+	if b.markerType != MarkerTypeRideHistory && b.markerType != MarkerTypeLocationShare {
+		return fmt.Errorf("smapp smappshot: marker_type must be 0 or 1, got %d", int(b.markerType))
+	}
+	return nil
+}
+
+// PreviewRequestBuilder builds and signs a URL for the /api/{version}/photo/preview endpoint.
+//
+// Usage:
+//
+//	url, err := smappshot.NewPreviewRequestBuilder(baseURL, signingConfig, smappshot.V1).
+//	    WithCenter(smappshot.Location{Lon: 51.338, Lat: 35.699}).
+//	    WithZoom(14).
+//	    Build()
+type PreviewRequestBuilder struct {
+	baseURL       string
+	signingConfig SigningConfig
+	version       Version
+	width         int
+	height        int
+	center        *Location
+	zoom          int
+	language      Language
+	style         string
+	tenant        string
+}
+
+// NewPreviewRequestBuilder creates a builder for the preview photo URL.
+func NewPreviewRequestBuilder(baseURL string, signingConfig SigningConfig, version Version) *PreviewRequestBuilder {
+	return &PreviewRequestBuilder{
+		baseURL:       strings.TrimRight(baseURL, "/"),
+		signingConfig: signingConfig,
+		version:       version,
+	}
+}
+
+func (b *PreviewRequestBuilder) WithWidth(w int) *PreviewRequestBuilder {
+	b.width = w
+	return b
+}
+
+func (b *PreviewRequestBuilder) WithHeight(h int) *PreviewRequestBuilder {
+	b.height = h
+	return b
+}
+
+func (b *PreviewRequestBuilder) WithCenter(loc Location) *PreviewRequestBuilder {
+	b.center = &loc
+	return b
+}
+
+func (b *PreviewRequestBuilder) WithZoom(zoom int) *PreviewRequestBuilder {
+	b.zoom = zoom
+	return b
+}
+
+func (b *PreviewRequestBuilder) WithLanguage(lang Language) *PreviewRequestBuilder {
+	b.language = lang
+	return b
+}
+
+func (b *PreviewRequestBuilder) WithStyle(style string) *PreviewRequestBuilder {
+	b.style = style
+	return b
+}
+
+func (b *PreviewRequestBuilder) WithTenant(tenant string) *PreviewRequestBuilder {
+	b.tenant = tenant
+	return b
+}
+
+// Build validates, signs, and returns the preview photo URL.
+func (b *PreviewRequestBuilder) Build() (string, error) {
+	if err := b.validate(); err != nil {
+		return "", err
+	}
+
+	params := url.Values{}
+	params.Set("width", strconv.Itoa(defaultInt(b.width, 512)))
+	params.Set("height", strconv.Itoa(defaultInt(b.height, 285)))
+	params.Set("center", formatLocation(*b.center))
+	params.Set("zoom", strconv.Itoa(defaultInt(b.zoom, 12)))
+	params.Set("language", string(defaultLanguage(b.language)))
+
+	if b.style != "" {
+		params.Set("style", b.style)
+	}
+
+	if b.tenant != "" {
+		params.Set("tenant", b.tenant)
+	}
+
+	return signURL(b.baseURL, fmt.Sprintf("/api/%s/photo/preview", b.version), b.signingConfig, params)
+}
+
+func (b *PreviewRequestBuilder) validate() error {
+	if err := validateSigningConfig(b.baseURL, b.signingConfig); err != nil {
+		return err
+	}
+	if b.version == "" {
+		return fmt.Errorf("smapp smappshot: version is required")
+	}
+	if b.center == nil {
+		return fmt.Errorf("smapp smappshot: center is required")
+	}
+	if b.language != "" {
+		if err := validateLanguage(b.language); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// signURL computes HMAC-SHA256 sig and returns the full signed URL.
+// A copy of params is made so the caller's url.Values is not modified.
+func signURL(baseURL, path string, cfg SigningConfig, params url.Values) (string, error) {
+	// Shallow copy: inner []string slices are shared, but we only Set new keys so this is safe.
+	p := make(url.Values, len(params)+1)
+	for k, v := range params {
+		p[k] = v
+	}
+	p.Set("expires", strconv.FormatInt(time.Now().UTC().Add(cfg.ExpiryDuration).Unix(), 10))
+
+	sig, err := computeSignature(cfg.Secret, path, p)
+	if err != nil {
+		return "", fmt.Errorf("smapp smappshot: signing failed: %w", err)
+	}
+
+	return baseURL + path + "?" + encodeParamsSorted(p) + "&sig=" + sig, nil
+}
+
+// computeSignature returns hex(HMAC-SHA256(secret, "GET\n{path}\n{sorted-params}")).
+func computeSignature(secret, path string, params url.Values) (string, error) {
+	message := "GET\n" + path + "\n" + encodeParamsSorted(params)
+	mac := hmac.New(sha256.New, []byte(secret))
+	if _, err := mac.Write([]byte(message)); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(mac.Sum(nil)), nil
+}
+
+// encodeParamsSorted sorts keys case-insensitively and percent-encodes key=value pairs.
+// sig must be excluded before calling.
+func encodeParamsSorted(params url.Values) string {
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return strings.ToLower(keys[i]) < strings.ToLower(keys[j])
+	})
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		for _, v := range params[k] {
+			parts = append(parts, url.QueryEscape(k)+"="+url.QueryEscape(v))
+		}
+	}
+	return strings.Join(parts, "&")
+}
+
+// formatLocation serializes a Location as "{lon},{lat}".
+func formatLocation(loc Location) string {
+	return strconv.FormatFloat(loc.Lon, 'f', -1, 64) + "," + strconv.FormatFloat(loc.Lat, 'f', -1, 64)
+}
+
+func validateLanguage(lang Language) error {
+	switch lang {
+	case LanguageFarsi, LanguageEnglish, LanguageArabic, LanguageKurdish:
+		return nil
+	}
+	return fmt.Errorf("smapp smappshot: language must be one of fa, en, ar, ku, got %q", string(lang))
+}
+
+func validateSigningConfig(baseURL string, cfg SigningConfig) error {
+	if baseURL == "" {
+		return fmt.Errorf("smapp smappshot: baseURL is required")
+	}
+	if cfg.Secret == "" {
+		return fmt.Errorf("smapp smappshot: signing secret is required")
+	}
+	if cfg.ExpiryDuration <= 0 {
+		return fmt.Errorf("smapp smappshot: expiry duration must be positive")
+	}
+	return nil
+}
+
+// defaultInt returns fallback when val is 0 (zero treated as "not set").
+func defaultInt(val, fallback int) int {
+	if val == 0 {
+		return fallback
+	}
+	return val
+}
+
+func defaultLanguage(lang Language) Language {
+	if lang == "" {
+		return LanguageFarsi
+	}
+	return lang
+}

--- a/services/smappshot/builder.go
+++ b/services/smappshot/builder.go
@@ -12,36 +12,40 @@ import (
 	"time"
 )
 
+const defaultExpiryDuration = 10 * time.Minute
+
 // RideRequestBuilder builds and signs a URL for the /api/{version}/photo/ride endpoint.
 // Either WithHere (single-point mode) or WithOrigin+WithDestinations (route mode) must be called.
 //
 // Usage:
 //
-//	url, err := smappshot.NewRideRequestBuilder(baseURL, signingConfig, smappshot.V1).
+//	url, err := smappshot.NewRideRequestBuilder(baseURL, secret, smappshot.V1).
 //	    WithOrigin(smappshot.Location{Lon: 51.338, Lat: 35.699}).
 //	    WithDestinations([]smappshot.Location{{Lon: 51.400, Lat: 35.720}}).
 //	    Build()
 type RideRequestBuilder struct {
-	baseURL       string
-	signingConfig SigningConfig
-	version       Version
-	width         int
-	height        int
-	here          *Location
-	origin        *Location
-	destinations  []Location
-	language      Language
-	style         string
-	markerType    MarkerType
-	tenant        string
+	baseURL        string
+	secret         string
+	expiryDuration time.Duration
+	version        Version
+	width          int
+	height         int
+	here           *Location
+	origin         *Location
+	destinations   []Location
+	language       Language
+	style          string
+	markerType     MarkerType
+	tenant         string
 }
 
 // NewRideRequestBuilder creates a builder for the ride photo URL.
-func NewRideRequestBuilder(baseURL string, signingConfig SigningConfig, version Version) *RideRequestBuilder {
+func NewRideRequestBuilder(baseURL string, secret string, version Version) *RideRequestBuilder {
 	return &RideRequestBuilder{
-		baseURL:       strings.TrimRight(baseURL, "/"),
-		signingConfig: signingConfig,
-		version:       version,
+		baseURL:        strings.TrimRight(baseURL, "/"),
+		secret:         secret,
+		expiryDuration: defaultExpiryDuration,
+		version:        version,
 	}
 }
 
@@ -52,6 +56,12 @@ func (b *RideRequestBuilder) WithWidth(w int) *RideRequestBuilder {
 
 func (b *RideRequestBuilder) WithHeight(h int) *RideRequestBuilder {
 	b.height = h
+	return b
+}
+
+// WithExpiry sets how long the signed URL remains valid. Default is 10 minutes.
+func (b *RideRequestBuilder) WithExpiry(d time.Duration) *RideRequestBuilder {
+	b.expiryDuration = d
 	return b
 }
 
@@ -130,12 +140,18 @@ func (b *RideRequestBuilder) Build() (string, error) {
 		params.Set("tenant", b.tenant)
 	}
 
-	return signURL(b.baseURL, fmt.Sprintf("/api/%s/photo/ride", b.version), b.signingConfig, params)
+	return signURL(b.baseURL, fmt.Sprintf("/api/%s/photo/ride", b.version), b.secret, b.expiryDuration, params)
 }
 
 func (b *RideRequestBuilder) validate() error {
-	if err := validateSigningConfig(b.baseURL, b.signingConfig); err != nil {
-		return err
+	if b.baseURL == "" {
+		return fmt.Errorf("smapp smappshot: baseURL is required")
+	}
+	if b.secret == "" {
+		return fmt.Errorf("smapp smappshot: signing secret is required")
+	}
+	if b.expiryDuration <= 0 {
+		return fmt.Errorf("smapp smappshot: expiry duration must be positive")
 	}
 	if b.version == "" {
 		return fmt.Errorf("smapp smappshot: version is required")
@@ -164,29 +180,31 @@ func (b *RideRequestBuilder) validate() error {
 //
 // Usage:
 //
-//	url, err := smappshot.NewPreviewRequestBuilder(baseURL, signingConfig, smappshot.V1).
+//	url, err := smappshot.NewPreviewRequestBuilder(baseURL, secret, smappshot.V1).
 //	    WithCenter(smappshot.Location{Lon: 51.338, Lat: 35.699}).
 //	    WithZoom(14).
 //	    Build()
 type PreviewRequestBuilder struct {
-	baseURL       string
-	signingConfig SigningConfig
-	version       Version
-	width         int
-	height        int
-	center        *Location
-	zoom          int
-	language      Language
-	style         string
-	tenant        string
+	baseURL        string
+	secret         string
+	expiryDuration time.Duration
+	version        Version
+	width          int
+	height         int
+	center         *Location
+	zoom           int
+	language       Language
+	style          string
+	tenant         string
 }
 
 // NewPreviewRequestBuilder creates a builder for the preview photo URL.
-func NewPreviewRequestBuilder(baseURL string, signingConfig SigningConfig, version Version) *PreviewRequestBuilder {
+func NewPreviewRequestBuilder(baseURL string, secret string, version Version) *PreviewRequestBuilder {
 	return &PreviewRequestBuilder{
-		baseURL:       strings.TrimRight(baseURL, "/"),
-		signingConfig: signingConfig,
-		version:       version,
+		baseURL:        strings.TrimRight(baseURL, "/"),
+		secret:         secret,
+		expiryDuration: defaultExpiryDuration,
+		version:        version,
 	}
 }
 
@@ -197,6 +215,12 @@ func (b *PreviewRequestBuilder) WithWidth(w int) *PreviewRequestBuilder {
 
 func (b *PreviewRequestBuilder) WithHeight(h int) *PreviewRequestBuilder {
 	b.height = h
+	return b
+}
+
+// WithExpiry sets how long the signed URL remains valid. Default is 10 minutes.
+func (b *PreviewRequestBuilder) WithExpiry(d time.Duration) *PreviewRequestBuilder {
+	b.expiryDuration = d
 	return b
 }
 
@@ -246,12 +270,18 @@ func (b *PreviewRequestBuilder) Build() (string, error) {
 		params.Set("tenant", b.tenant)
 	}
 
-	return signURL(b.baseURL, fmt.Sprintf("/api/%s/photo/preview", b.version), b.signingConfig, params)
+	return signURL(b.baseURL, fmt.Sprintf("/api/%s/photo/preview", b.version), b.secret, b.expiryDuration, params)
 }
 
 func (b *PreviewRequestBuilder) validate() error {
-	if err := validateSigningConfig(b.baseURL, b.signingConfig); err != nil {
-		return err
+	if b.baseURL == "" {
+		return fmt.Errorf("smapp smappshot: baseURL is required")
+	}
+	if b.secret == "" {
+		return fmt.Errorf("smapp smappshot: signing secret is required")
+	}
+	if b.expiryDuration <= 0 {
+		return fmt.Errorf("smapp smappshot: expiry duration must be positive")
 	}
 	if b.version == "" {
 		return fmt.Errorf("smapp smappshot: version is required")
@@ -268,16 +298,14 @@ func (b *PreviewRequestBuilder) validate() error {
 }
 
 // signURL computes HMAC-SHA256 sig and returns the full signed URL.
-// A copy of params is made so the caller's url.Values is not modified.
-func signURL(baseURL, path string, cfg SigningConfig, params url.Values) (string, error) {
-	// Shallow copy: inner []string slices are shared, but we only Set new keys so this is safe.
+func signURL(baseURL, path, secret string, expiry time.Duration, params url.Values) (string, error) {
 	p := make(url.Values, len(params)+1)
 	for k, v := range params {
 		p[k] = v
 	}
-	p.Set("expires", strconv.FormatInt(time.Now().UTC().Add(cfg.ExpiryDuration).Unix(), 10))
+	p.Set("expires", strconv.FormatInt(time.Now().UTC().Add(expiry).Unix(), 10))
 
-	sig, err := computeSignature(cfg.Secret, path, p)
+	sig, err := computeSignature(secret, path, p)
 	if err != nil {
 		return "", fmt.Errorf("smapp smappshot: signing failed: %w", err)
 	}
@@ -327,20 +355,6 @@ func validateLanguage(lang Language) error {
 	return fmt.Errorf("smapp smappshot: language must be one of fa, en, ar, ku, got %q", string(lang))
 }
 
-func validateSigningConfig(baseURL string, cfg SigningConfig) error {
-	if baseURL == "" {
-		return fmt.Errorf("smapp smappshot: baseURL is required")
-	}
-	if cfg.Secret == "" {
-		return fmt.Errorf("smapp smappshot: signing secret is required")
-	}
-	if cfg.ExpiryDuration <= 0 {
-		return fmt.Errorf("smapp smappshot: expiry duration must be positive")
-	}
-	return nil
-}
-
-// defaultInt returns fallback when val is 0 (zero treated as "not set").
 func defaultInt(val, fallback int) int {
 	if val == 0 {
 		return fallback

--- a/services/smappshot/models.go
+++ b/services/smappshot/models.go
@@ -26,6 +26,14 @@ const (
 	MarkerTypeLocationShare MarkerType = 1
 )
 
+// Tenant identifies the deployment target for multi-tenant SmappShot instances.
+type Tenant string
+
+const (
+	TenantBalyIQ  Tenant = "baly-iq"
+	TenantBalyLBN Tenant = "baly-lbn"
+)
+
 // Location is a geographic coordinate. Longitude comes first, matching the SmappShot wire format.
 type Location struct {
 	Lon float64 // longitude

--- a/services/smappshot/models.go
+++ b/services/smappshot/models.go
@@ -1,0 +1,41 @@
+package smappshot
+
+import "time"
+
+// Version represents the SmappShot API version.
+type Version string
+
+const (
+	V1 Version = "v1"
+	V2 Version = "v2"
+)
+
+// Language represents supported map languages.
+type Language string
+
+const (
+	LanguageFarsi   Language = "fa"
+	LanguageEnglish Language = "en"
+	LanguageArabic  Language = "ar"
+	LanguageKurdish Language = "ku"
+)
+
+// MarkerType represents the type of map marker rendered on ride photos.
+type MarkerType int
+
+const (
+	MarkerTypeRideHistory   MarkerType = 0
+	MarkerTypeLocationShare MarkerType = 1
+)
+
+// Location is a geographic coordinate. Longitude comes first, matching the SmappShot wire format.
+type Location struct {
+	Lon float64 // longitude
+	Lat float64 // latitude
+}
+
+// SigningConfig holds HMAC-SHA256 URL signing parameters.
+type SigningConfig struct {
+	Secret         string
+	ExpiryDuration time.Duration
+}

--- a/services/smappshot/models.go
+++ b/services/smappshot/models.go
@@ -1,7 +1,5 @@
 package smappshot
 
-import "time"
-
 // Version represents the SmappShot API version.
 type Version string
 
@@ -32,10 +30,4 @@ const (
 type Location struct {
 	Lon float64 // longitude
 	Lat float64 // latitude
-}
-
-// SigningConfig holds HMAC-SHA256 URL signing parameters.
-type SigningConfig struct {
-	Secret         string
-	ExpiryDuration time.Duration
 }

--- a/services/smappshot/signing.go
+++ b/services/smappshot/signing.go
@@ -1,0 +1,84 @@
+package smappshot
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// signURL appends expires, computes HMAC-SHA256 sig, returns full signed URL.
+func signURL(baseURL, path, secret string, expiry time.Duration, params url.Values) (string, error) {
+	p := make(url.Values, len(params)+1)
+	for k, v := range params {
+		p[k] = v
+	}
+	p.Set("expires", strconv.FormatInt(time.Now().UTC().Add(expiry).Unix(), 10))
+
+	sig, err := computeSignature(secret, path, p)
+	if err != nil {
+		return "", fmt.Errorf("smapp smappshot: signing failed: %w", err)
+	}
+	return baseURL + path + "?" + encodeParamsSorted(p) + "&sig=" + sig, nil
+}
+
+// computeSignature returns hex(HMAC-SHA256(secret, "GET\n{path}\n{sorted-params}")).
+func computeSignature(secret, path string, params url.Values) (string, error) {
+	message := "GET\n" + path + "\n" + encodeParamsSorted(params)
+	mac := hmac.New(sha256.New, []byte(secret))
+	if _, err := mac.Write([]byte(message)); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(mac.Sum(nil)), nil
+}
+
+// encodeParamsSorted sorts keys case-insensitively and percent-encodes key=value pairs.
+// sig must be excluded before calling.
+func encodeParamsSorted(params url.Values) string {
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return strings.ToLower(keys[i]) < strings.ToLower(keys[j])
+	})
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		for _, v := range params[k] {
+			parts = append(parts, url.QueryEscape(k)+"="+url.QueryEscape(v))
+		}
+	}
+	return strings.Join(parts, "&")
+}
+
+// formatLocation serializes a Location as "{lon},{lat}".
+func formatLocation(loc Location) string {
+	return strconv.FormatFloat(loc.Lon, 'f', -1, 64) + "," + strconv.FormatFloat(loc.Lat, 'f', -1, 64)
+}
+
+func validateLanguage(lang Language) error {
+	switch lang {
+	case LanguageFarsi, LanguageEnglish, LanguageArabic, LanguageKurdish:
+		return nil
+	}
+	return fmt.Errorf("smapp smappshot: language must be one of fa, en, ar, ku, got %q", string(lang))
+}
+
+func defaultInt(val, fallback int) int {
+	if val == 0 {
+		return fallback
+	}
+	return val
+}
+
+func defaultLanguage(lang Language) Language {
+	if lang == "" {
+		return LanguageFarsi
+	}
+	return lang
+}

--- a/services/smappshot/smappshot_test.go
+++ b/services/smappshot/smappshot_test.go
@@ -12,31 +12,12 @@ const (
 	testSecret  = "test-secret-key"
 )
 
-func testSigningConfig() SigningConfig {
-	return SigningConfig{
-		Secret:         testSecret,
-		ExpiryDuration: time.Hour,
-	}
-}
-
-func parseSigned(t *testing.T, rawURL string) (path string, params url.Values, sig string) {
-	t.Helper()
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		t.Fatalf("invalid URL %q: %v", rawURL, err)
-	}
-	q := u.Query()
-	sig = q.Get("sig")
-	q.Del("sig")
-	return u.Path, q, sig
-}
-
 // ---------------------------------------------------------------------------
 // RideRequestBuilder
 // ---------------------------------------------------------------------------
 
 func TestRideRequestBuilder_HereMode(t *testing.T) {
-	rawURL, err := NewRideRequestBuilder(testBaseURL, testSigningConfig(), V2).
+	rawURL, err := NewRideRequestBuilder(testBaseURL, testSecret, V2).
 		WithHere(Location{Lon: 51.338, Lat: 35.699}).
 		WithLanguage(LanguageEnglish).
 		Build()
@@ -60,7 +41,7 @@ func TestRideRequestBuilder_HereMode(t *testing.T) {
 }
 
 func TestRideRequestBuilder_RouteMode(t *testing.T) {
-	rawURL, err := NewRideRequestBuilder(testBaseURL, testSigningConfig(), V2).
+	rawURL, err := NewRideRequestBuilder(testBaseURL, testSecret, V2).
 		WithOrigin(Location{Lon: 51.338, Lat: 35.699}).
 		WithDestinations([]Location{
 			{Lon: 51.400, Lat: 35.720},
@@ -84,7 +65,7 @@ func TestRideRequestBuilder_RouteMode(t *testing.T) {
 }
 
 func TestRideRequestBuilder_DefaultDimensions(t *testing.T) {
-	rawURL, err := NewRideRequestBuilder(testBaseURL, testSigningConfig(), V1).
+	rawURL, err := NewRideRequestBuilder(testBaseURL, testSecret, V1).
 		WithHere(Location{Lon: 51.338, Lat: 35.699}).
 		Build()
 	if err != nil {
@@ -100,7 +81,7 @@ func TestRideRequestBuilder_DefaultDimensions(t *testing.T) {
 }
 
 func TestRideRequestBuilder_CustomDimensions(t *testing.T) {
-	rawURL, err := NewRideRequestBuilder(testBaseURL, testSigningConfig(), V1).
+	rawURL, err := NewRideRequestBuilder(testBaseURL, testSecret, V1).
 		WithHere(Location{Lon: 51.338, Lat: 35.699}).
 		WithWidth(800).
 		WithHeight(600).
@@ -118,7 +99,7 @@ func TestRideRequestBuilder_CustomDimensions(t *testing.T) {
 }
 
 func TestRideRequestBuilder_DefaultLanguage(t *testing.T) {
-	rawURL, err := NewRideRequestBuilder(testBaseURL, testSigningConfig(), V1).
+	rawURL, err := NewRideRequestBuilder(testBaseURL, testSecret, V1).
 		WithHere(Location{Lon: 51.338, Lat: 35.699}).
 		Build()
 	if err != nil {
@@ -131,7 +112,7 @@ func TestRideRequestBuilder_DefaultLanguage(t *testing.T) {
 }
 
 func TestRideRequestBuilder_TenantParam(t *testing.T) {
-	rawURL, err := NewRideRequestBuilder(testBaseURL, testSigningConfig(), V1).
+	rawURL, err := NewRideRequestBuilder(testBaseURL, testSecret, V1).
 		WithHere(Location{Lon: 51.338, Lat: 35.699}).
 		WithTenant("baly-iq").
 		Build()
@@ -145,7 +126,7 @@ func TestRideRequestBuilder_TenantParam(t *testing.T) {
 }
 
 func TestRideRequestBuilder_SignatureVerification(t *testing.T) {
-	rawURL, err := NewRideRequestBuilder(testBaseURL, testSigningConfig(), V1).
+	rawURL, err := NewRideRequestBuilder(testBaseURL, testSecret, V1).
 		WithHere(Location{Lon: 51.338, Lat: 35.699}).
 		Build()
 	if err != nil {
@@ -170,7 +151,7 @@ func TestRideRequestBuilder_SignatureVerification(t *testing.T) {
 }
 
 func TestRideRequestBuilder_BaseURLInResult(t *testing.T) {
-	rawURL, err := NewRideRequestBuilder(testBaseURL, testSigningConfig(), V1).
+	rawURL, err := NewRideRequestBuilder(testBaseURL, testSecret, V1).
 		WithHere(Location{Lon: 51.338, Lat: 35.699}).
 		Build()
 	if err != nil {
@@ -181,12 +162,26 @@ func TestRideRequestBuilder_BaseURLInResult(t *testing.T) {
 	}
 }
 
+func TestRideRequestBuilder_CustomExpiry(t *testing.T) {
+	rawURL, err := NewRideRequestBuilder(testBaseURL, testSecret, V1).
+		WithHere(Location{Lon: 51.338, Lat: 35.699}).
+		WithExpiry(30 * time.Minute).
+		Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_, params, _ := parseSigned(t, rawURL)
+	if params.Get("expires") == "" {
+		t.Error("expires param missing")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // RideRequestBuilder validation errors
 // ---------------------------------------------------------------------------
 
 func TestRideRequestBuilder_ErrorMissingVersion(t *testing.T) {
-	_, err := NewRideRequestBuilder(testBaseURL, testSigningConfig(), "").
+	_, err := NewRideRequestBuilder(testBaseURL, testSecret, "").
 		WithHere(Location{Lon: 51.338, Lat: 35.699}).
 		Build()
 	if err == nil {
@@ -195,7 +190,7 @@ func TestRideRequestBuilder_ErrorMissingVersion(t *testing.T) {
 }
 
 func TestRideRequestBuilder_ErrorMissingSecret(t *testing.T) {
-	_, err := NewRideRequestBuilder(testBaseURL, SigningConfig{ExpiryDuration: time.Hour}, V1).
+	_, err := NewRideRequestBuilder(testBaseURL, "", V1).
 		WithHere(Location{Lon: 51.338, Lat: 35.699}).
 		Build()
 	if err == nil {
@@ -204,8 +199,9 @@ func TestRideRequestBuilder_ErrorMissingSecret(t *testing.T) {
 }
 
 func TestRideRequestBuilder_ErrorZeroExpiry(t *testing.T) {
-	_, err := NewRideRequestBuilder(testBaseURL, SigningConfig{Secret: "s"}, V1).
+	_, err := NewRideRequestBuilder(testBaseURL, testSecret, V1).
 		WithHere(Location{Lon: 51.338, Lat: 35.699}).
+		WithExpiry(0).
 		Build()
 	if err == nil {
 		t.Fatal("expected error for zero expiry duration")
@@ -213,7 +209,7 @@ func TestRideRequestBuilder_ErrorZeroExpiry(t *testing.T) {
 }
 
 func TestRideRequestBuilder_ErrorMissingOrigin(t *testing.T) {
-	_, err := NewRideRequestBuilder(testBaseURL, testSigningConfig(), V1).
+	_, err := NewRideRequestBuilder(testBaseURL, testSecret, V1).
 		WithDestinations([]Location{{Lon: 51.410, Lat: 35.730}}).
 		Build()
 	if err == nil {
@@ -222,7 +218,7 @@ func TestRideRequestBuilder_ErrorMissingOrigin(t *testing.T) {
 }
 
 func TestRideRequestBuilder_ErrorMissingDestinations(t *testing.T) {
-	_, err := NewRideRequestBuilder(testBaseURL, testSigningConfig(), V1).
+	_, err := NewRideRequestBuilder(testBaseURL, testSecret, V1).
 		WithOrigin(Location{Lon: 51.338, Lat: 35.699}).
 		Build()
 	if err == nil {
@@ -231,7 +227,7 @@ func TestRideRequestBuilder_ErrorMissingDestinations(t *testing.T) {
 }
 
 func TestRideRequestBuilder_ErrorInvalidLanguage(t *testing.T) {
-	_, err := NewRideRequestBuilder(testBaseURL, testSigningConfig(), V1).
+	_, err := NewRideRequestBuilder(testBaseURL, testSecret, V1).
 		WithHere(Location{Lon: 51.338, Lat: 35.699}).
 		WithLanguage("zz").
 		Build()
@@ -241,7 +237,7 @@ func TestRideRequestBuilder_ErrorInvalidLanguage(t *testing.T) {
 }
 
 func TestRideRequestBuilder_ErrorInvalidMarkerType(t *testing.T) {
-	_, err := NewRideRequestBuilder(testBaseURL, testSigningConfig(), V1).
+	_, err := NewRideRequestBuilder(testBaseURL, testSecret, V1).
 		WithHere(Location{Lon: 51.338, Lat: 35.699}).
 		WithMarkerType(99).
 		Build()
@@ -255,7 +251,7 @@ func TestRideRequestBuilder_ErrorInvalidMarkerType(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestPreviewRequestBuilder_Success(t *testing.T) {
-	rawURL, err := NewPreviewRequestBuilder(testBaseURL, testSigningConfig(), V2).
+	rawURL, err := NewPreviewRequestBuilder(testBaseURL, testSecret, V2).
 		WithCenter(Location{Lon: 51.338, Lat: 35.699}).
 		Build()
 	if err != nil {
@@ -275,7 +271,7 @@ func TestPreviewRequestBuilder_Success(t *testing.T) {
 }
 
 func TestPreviewRequestBuilder_DefaultZoom(t *testing.T) {
-	rawURL, err := NewPreviewRequestBuilder(testBaseURL, testSigningConfig(), V1).
+	rawURL, err := NewPreviewRequestBuilder(testBaseURL, testSecret, V1).
 		WithCenter(Location{Lon: 51.338, Lat: 35.699}).
 		Build()
 	if err != nil {
@@ -288,7 +284,7 @@ func TestPreviewRequestBuilder_DefaultZoom(t *testing.T) {
 }
 
 func TestPreviewRequestBuilder_CustomZoom(t *testing.T) {
-	rawURL, err := NewPreviewRequestBuilder(testBaseURL, testSigningConfig(), V1).
+	rawURL, err := NewPreviewRequestBuilder(testBaseURL, testSecret, V1).
 		WithCenter(Location{Lon: 51.338, Lat: 35.699}).
 		WithZoom(16).
 		Build()
@@ -302,7 +298,7 @@ func TestPreviewRequestBuilder_CustomZoom(t *testing.T) {
 }
 
 func TestPreviewRequestBuilder_TenantParam(t *testing.T) {
-	rawURL, err := NewPreviewRequestBuilder(testBaseURL, testSigningConfig(), V1).
+	rawURL, err := NewPreviewRequestBuilder(testBaseURL, testSecret, V1).
 		WithCenter(Location{Lon: 51.338, Lat: 35.699}).
 		WithTenant("baly-lbn").
 		Build()
@@ -316,7 +312,7 @@ func TestPreviewRequestBuilder_TenantParam(t *testing.T) {
 }
 
 func TestPreviewRequestBuilder_SignatureVerification(t *testing.T) {
-	rawURL, err := NewPreviewRequestBuilder(testBaseURL, testSigningConfig(), V1).
+	rawURL, err := NewPreviewRequestBuilder(testBaseURL, testSecret, V1).
 		WithCenter(Location{Lon: 51.338, Lat: 35.699}).
 		Build()
 	if err != nil {
@@ -340,12 +336,26 @@ func TestPreviewRequestBuilder_SignatureVerification(t *testing.T) {
 	}
 }
 
+func TestPreviewRequestBuilder_CustomExpiry(t *testing.T) {
+	rawURL, err := NewPreviewRequestBuilder(testBaseURL, testSecret, V1).
+		WithCenter(Location{Lon: 51.338, Lat: 35.699}).
+		WithExpiry(5 * time.Minute).
+		Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_, params, _ := parseSigned(t, rawURL)
+	if params.Get("expires") == "" {
+		t.Error("expires param missing")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // PreviewRequestBuilder validation errors
 // ---------------------------------------------------------------------------
 
 func TestPreviewRequestBuilder_ErrorMissingVersion(t *testing.T) {
-	_, err := NewPreviewRequestBuilder(testBaseURL, testSigningConfig(), "").
+	_, err := NewPreviewRequestBuilder(testBaseURL, testSecret, "").
 		WithCenter(Location{Lon: 51.338, Lat: 35.699}).
 		Build()
 	if err == nil {
@@ -354,14 +364,14 @@ func TestPreviewRequestBuilder_ErrorMissingVersion(t *testing.T) {
 }
 
 func TestPreviewRequestBuilder_ErrorMissingCenter(t *testing.T) {
-	_, err := NewPreviewRequestBuilder(testBaseURL, testSigningConfig(), V1).Build()
+	_, err := NewPreviewRequestBuilder(testBaseURL, testSecret, V1).Build()
 	if err == nil {
 		t.Fatal("expected error for missing center")
 	}
 }
 
 func TestPreviewRequestBuilder_ErrorInvalidLanguage(t *testing.T) {
-	_, err := NewPreviewRequestBuilder(testBaseURL, testSigningConfig(), V1).
+	_, err := NewPreviewRequestBuilder(testBaseURL, testSecret, V1).
 		WithCenter(Location{Lon: 51.338, Lat: 35.699}).
 		WithLanguage("xx").
 		Build()
@@ -379,4 +389,20 @@ func TestFormatLocation(t *testing.T) {
 	if got != "51.338,35.699" {
 		t.Errorf("formatLocation = %q, want 51.338,35.699", got)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func parseSigned(t *testing.T, rawURL string) (path string, params url.Values, sig string) {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("invalid URL %q: %v", rawURL, err)
+	}
+	q := u.Query()
+	sig = q.Get("sig")
+	q.Del("sig")
+	return u.Path, q, sig
 }

--- a/services/smappshot/smappshot_test.go
+++ b/services/smappshot/smappshot_test.go
@@ -1,0 +1,382 @@
+package smappshot
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	testBaseURL = "https://smappshot.example.com"
+	testSecret  = "test-secret-key"
+)
+
+func testSigningConfig() SigningConfig {
+	return SigningConfig{
+		Secret:         testSecret,
+		ExpiryDuration: time.Hour,
+	}
+}
+
+func parseSigned(t *testing.T, rawURL string) (path string, params url.Values, sig string) {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("invalid URL %q: %v", rawURL, err)
+	}
+	q := u.Query()
+	sig = q.Get("sig")
+	q.Del("sig")
+	return u.Path, q, sig
+}
+
+// ---------------------------------------------------------------------------
+// RideRequestBuilder
+// ---------------------------------------------------------------------------
+
+func TestRideRequestBuilder_HereMode(t *testing.T) {
+	rawURL, err := NewRideRequestBuilder(testBaseURL, testSigningConfig(), V2).
+		WithHere(Location{Lon: 51.338, Lat: 35.699}).
+		WithLanguage(LanguageEnglish).
+		Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	path, params, sig := parseSigned(t, rawURL)
+	if path != "/api/v2/photo/ride" {
+		t.Errorf("path = %q", path)
+	}
+	if params.Get("here") == "" {
+		t.Error("here param missing")
+	}
+	if params.Get("origin") != "" || params.Get("destinations") != "" {
+		t.Error("origin/destinations should be absent in here mode")
+	}
+	if sig == "" {
+		t.Error("sig param missing")
+	}
+}
+
+func TestRideRequestBuilder_RouteMode(t *testing.T) {
+	rawURL, err := NewRideRequestBuilder(testBaseURL, testSigningConfig(), V2).
+		WithOrigin(Location{Lon: 51.338, Lat: 35.699}).
+		WithDestinations([]Location{
+			{Lon: 51.400, Lat: 35.720},
+			{Lon: 51.420, Lat: 35.730},
+		}).
+		Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	_, params, sig := parseSigned(t, rawURL)
+	if params.Get("origin") == "" {
+		t.Error("origin param missing")
+	}
+	if strings.Count(params.Get("destinations"), ";") != 1 {
+		t.Errorf("expected 2 destinations separated by ';', got %q", params.Get("destinations"))
+	}
+	if sig == "" {
+		t.Error("sig param missing")
+	}
+}
+
+func TestRideRequestBuilder_DefaultDimensions(t *testing.T) {
+	rawURL, err := NewRideRequestBuilder(testBaseURL, testSigningConfig(), V1).
+		WithHere(Location{Lon: 51.338, Lat: 35.699}).
+		Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_, params, _ := parseSigned(t, rawURL)
+	if params.Get("width") != "512" {
+		t.Errorf("default width = %q, want 512", params.Get("width"))
+	}
+	if params.Get("height") != "285" {
+		t.Errorf("default height = %q, want 285", params.Get("height"))
+	}
+}
+
+func TestRideRequestBuilder_CustomDimensions(t *testing.T) {
+	rawURL, err := NewRideRequestBuilder(testBaseURL, testSigningConfig(), V1).
+		WithHere(Location{Lon: 51.338, Lat: 35.699}).
+		WithWidth(800).
+		WithHeight(600).
+		Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_, params, _ := parseSigned(t, rawURL)
+	if params.Get("width") != "800" {
+		t.Errorf("width = %q, want 800", params.Get("width"))
+	}
+	if params.Get("height") != "600" {
+		t.Errorf("height = %q, want 600", params.Get("height"))
+	}
+}
+
+func TestRideRequestBuilder_DefaultLanguage(t *testing.T) {
+	rawURL, err := NewRideRequestBuilder(testBaseURL, testSigningConfig(), V1).
+		WithHere(Location{Lon: 51.338, Lat: 35.699}).
+		Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_, params, _ := parseSigned(t, rawURL)
+	if params.Get("language") != "fa" {
+		t.Errorf("default language = %q, want fa", params.Get("language"))
+	}
+}
+
+func TestRideRequestBuilder_TenantParam(t *testing.T) {
+	rawURL, err := NewRideRequestBuilder(testBaseURL, testSigningConfig(), V1).
+		WithHere(Location{Lon: 51.338, Lat: 35.699}).
+		WithTenant("baly-iq").
+		Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_, params, _ := parseSigned(t, rawURL)
+	if params.Get("tenant") != "baly-iq" {
+		t.Errorf("tenant = %q, want baly-iq", params.Get("tenant"))
+	}
+}
+
+func TestRideRequestBuilder_SignatureVerification(t *testing.T) {
+	rawURL, err := NewRideRequestBuilder(testBaseURL, testSigningConfig(), V1).
+		WithHere(Location{Lon: 51.338, Lat: 35.699}).
+		Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("url.Parse: %v", err)
+	}
+	q := u.Query()
+	sig := q.Get("sig")
+	q.Del("sig")
+
+	expected, err := computeSignature(testSecret, u.Path, q)
+	if err != nil {
+		t.Fatalf("computeSignature error: %v", err)
+	}
+	if sig != expected {
+		t.Errorf("signature mismatch: got %q, want %q", sig, expected)
+	}
+}
+
+func TestRideRequestBuilder_BaseURLInResult(t *testing.T) {
+	rawURL, err := NewRideRequestBuilder(testBaseURL, testSigningConfig(), V1).
+		WithHere(Location{Lon: 51.338, Lat: 35.699}).
+		Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(rawURL, testBaseURL) {
+		t.Errorf("URL %q does not start with base %q", rawURL, testBaseURL)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RideRequestBuilder validation errors
+// ---------------------------------------------------------------------------
+
+func TestRideRequestBuilder_ErrorMissingVersion(t *testing.T) {
+	_, err := NewRideRequestBuilder(testBaseURL, testSigningConfig(), "").
+		WithHere(Location{Lon: 51.338, Lat: 35.699}).
+		Build()
+	if err == nil {
+		t.Fatal("expected error for missing version")
+	}
+}
+
+func TestRideRequestBuilder_ErrorMissingSecret(t *testing.T) {
+	_, err := NewRideRequestBuilder(testBaseURL, SigningConfig{ExpiryDuration: time.Hour}, V1).
+		WithHere(Location{Lon: 51.338, Lat: 35.699}).
+		Build()
+	if err == nil {
+		t.Fatal("expected error for missing secret")
+	}
+}
+
+func TestRideRequestBuilder_ErrorZeroExpiry(t *testing.T) {
+	_, err := NewRideRequestBuilder(testBaseURL, SigningConfig{Secret: "s"}, V1).
+		WithHere(Location{Lon: 51.338, Lat: 35.699}).
+		Build()
+	if err == nil {
+		t.Fatal("expected error for zero expiry duration")
+	}
+}
+
+func TestRideRequestBuilder_ErrorMissingOrigin(t *testing.T) {
+	_, err := NewRideRequestBuilder(testBaseURL, testSigningConfig(), V1).
+		WithDestinations([]Location{{Lon: 51.410, Lat: 35.730}}).
+		Build()
+	if err == nil {
+		t.Fatal("expected error for missing origin")
+	}
+}
+
+func TestRideRequestBuilder_ErrorMissingDestinations(t *testing.T) {
+	_, err := NewRideRequestBuilder(testBaseURL, testSigningConfig(), V1).
+		WithOrigin(Location{Lon: 51.338, Lat: 35.699}).
+		Build()
+	if err == nil {
+		t.Fatal("expected error for missing destinations")
+	}
+}
+
+func TestRideRequestBuilder_ErrorInvalidLanguage(t *testing.T) {
+	_, err := NewRideRequestBuilder(testBaseURL, testSigningConfig(), V1).
+		WithHere(Location{Lon: 51.338, Lat: 35.699}).
+		WithLanguage("zz").
+		Build()
+	if err == nil {
+		t.Fatal("expected error for invalid language")
+	}
+}
+
+func TestRideRequestBuilder_ErrorInvalidMarkerType(t *testing.T) {
+	_, err := NewRideRequestBuilder(testBaseURL, testSigningConfig(), V1).
+		WithHere(Location{Lon: 51.338, Lat: 35.699}).
+		WithMarkerType(99).
+		Build()
+	if err == nil {
+		t.Fatal("expected error for invalid marker_type")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PreviewRequestBuilder
+// ---------------------------------------------------------------------------
+
+func TestPreviewRequestBuilder_Success(t *testing.T) {
+	rawURL, err := NewPreviewRequestBuilder(testBaseURL, testSigningConfig(), V2).
+		WithCenter(Location{Lon: 51.338, Lat: 35.699}).
+		Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	path, params, sig := parseSigned(t, rawURL)
+	if path != "/api/v2/photo/preview" {
+		t.Errorf("path = %q", path)
+	}
+	if params.Get("center") == "" {
+		t.Error("center param missing")
+	}
+	if sig == "" {
+		t.Error("sig param missing")
+	}
+}
+
+func TestPreviewRequestBuilder_DefaultZoom(t *testing.T) {
+	rawURL, err := NewPreviewRequestBuilder(testBaseURL, testSigningConfig(), V1).
+		WithCenter(Location{Lon: 51.338, Lat: 35.699}).
+		Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_, params, _ := parseSigned(t, rawURL)
+	if params.Get("zoom") != "12" {
+		t.Errorf("default zoom = %q, want 12", params.Get("zoom"))
+	}
+}
+
+func TestPreviewRequestBuilder_CustomZoom(t *testing.T) {
+	rawURL, err := NewPreviewRequestBuilder(testBaseURL, testSigningConfig(), V1).
+		WithCenter(Location{Lon: 51.338, Lat: 35.699}).
+		WithZoom(16).
+		Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_, params, _ := parseSigned(t, rawURL)
+	if params.Get("zoom") != "16" {
+		t.Errorf("zoom = %q, want 16", params.Get("zoom"))
+	}
+}
+
+func TestPreviewRequestBuilder_TenantParam(t *testing.T) {
+	rawURL, err := NewPreviewRequestBuilder(testBaseURL, testSigningConfig(), V1).
+		WithCenter(Location{Lon: 51.338, Lat: 35.699}).
+		WithTenant("baly-lbn").
+		Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_, params, _ := parseSigned(t, rawURL)
+	if params.Get("tenant") != "baly-lbn" {
+		t.Errorf("tenant = %q, want baly-lbn", params.Get("tenant"))
+	}
+}
+
+func TestPreviewRequestBuilder_SignatureVerification(t *testing.T) {
+	rawURL, err := NewPreviewRequestBuilder(testBaseURL, testSigningConfig(), V1).
+		WithCenter(Location{Lon: 51.338, Lat: 35.699}).
+		Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("url.Parse: %v", err)
+	}
+	q := u.Query()
+	sig := q.Get("sig")
+	q.Del("sig")
+
+	expected, err := computeSignature(testSecret, u.Path, q)
+	if err != nil {
+		t.Fatalf("computeSignature error: %v", err)
+	}
+	if sig != expected {
+		t.Errorf("signature mismatch: got %q, want %q", sig, expected)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PreviewRequestBuilder validation errors
+// ---------------------------------------------------------------------------
+
+func TestPreviewRequestBuilder_ErrorMissingVersion(t *testing.T) {
+	_, err := NewPreviewRequestBuilder(testBaseURL, testSigningConfig(), "").
+		WithCenter(Location{Lon: 51.338, Lat: 35.699}).
+		Build()
+	if err == nil {
+		t.Fatal("expected error for missing version")
+	}
+}
+
+func TestPreviewRequestBuilder_ErrorMissingCenter(t *testing.T) {
+	_, err := NewPreviewRequestBuilder(testBaseURL, testSigningConfig(), V1).Build()
+	if err == nil {
+		t.Fatal("expected error for missing center")
+	}
+}
+
+func TestPreviewRequestBuilder_ErrorInvalidLanguage(t *testing.T) {
+	_, err := NewPreviewRequestBuilder(testBaseURL, testSigningConfig(), V1).
+		WithCenter(Location{Lon: 51.338, Lat: 35.699}).
+		WithLanguage("xx").
+		Build()
+	if err == nil {
+		t.Fatal("expected error for invalid language")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// formatLocation
+// ---------------------------------------------------------------------------
+
+func TestFormatLocation(t *testing.T) {
+	got := formatLocation(Location{Lon: 51.338, Lat: 35.699})
+	if got != "51.338,35.699" {
+		t.Errorf("formatLocation = %q, want 51.338,35.699", got)
+	}
+}

--- a/services/smappshot/smappshot_test.go
+++ b/services/smappshot/smappshot_test.go
@@ -114,7 +114,7 @@ func TestRideRequestBuilder_DefaultLanguage(t *testing.T) {
 func TestRideRequestBuilder_TenantParam(t *testing.T) {
 	rawURL, err := NewRideRequestBuilder(testBaseURL, testSecret, V1).
 		WithHere(Location{Lon: 51.338, Lat: 35.699}).
-		WithTenant("baly-iq").
+		WithTenant(TenantBalyIQ).
 		Build()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -300,7 +300,7 @@ func TestPreviewRequestBuilder_CustomZoom(t *testing.T) {
 func TestPreviewRequestBuilder_TenantParam(t *testing.T) {
 	rawURL, err := NewPreviewRequestBuilder(testBaseURL, testSecret, V1).
 		WithCenter(Location{Lon: 51.338, Lat: 35.699}).
-		WithTenant("baly-lbn").
+		WithTenant(TenantBalyLBN).
 		Build()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
## Summary

- Adds `services/smappshot` package with `RideRequestBuilder` and `PreviewRequestBuilder`
- Builders produce HMAC-SHA256 signed URLs for `/api/{version}/photo/ride` and `/api/{version}/photo/preview` endpoints
- Pure URL construction — no HTTP calls, no `Client` struct, no mock needed

## Design

Fluent builder API:
```go
url, err := smappshot.NewRideRequestBuilder(baseURL, signingConfig, smappshot.V1).
    WithOrigin(smappshot.Location{Lon: 51.338, Lat: 35.699}).
    WithDestinations([]smappshot.Location{{Lon: 51.400, Lat: 35.720}}).
    Build()
```